### PR TITLE
Makefile and work experience environments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+NAME=cv
+
+all:
+	latexmk -pdf ${NAME}.tex
+
+clean:
+	rm -f ${NAME}.aux ${NAME}.bbl ${NAME}.bcf ${NAME}.fdb_latexmk ${NAME}.fls ${NAME}.log ${NAME}.out ${NAME}.run.xml ${NAME}.blg ${NAME}.toc *\~
+
+distclean: clean
+	rm -f ${NAME}.pdf

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Now, once your site is published, your CV will be accessible at: https://usernam
 
 Also, if you have a premium subscription to Overleaf, you can use Overleaf's GitHub integration to push changes to your GitHub repo directly from Overleaf.
 
+## Compiling the CV on your local computer
+- type `make` in the `autoCV` directory to produce file `cv.pdf`
+- you can optionally type `make clean` or `make distclean` to remove intermediate files
+
 ## Detailed Instructions..
 
 [.. are available here](https://github.com/jitinnair1/autoCV/wiki/How-to-use-autoCV:-Detailed-Instructions)

--- a/cv.tex
+++ b/cv.tex
@@ -97,6 +97,32 @@
 %debug page outer frames
 %\usepackage{showframe}
 
+
+% job listing environments
+\newenvironment{jobshort}[2]
+    {
+    \begin{tabularx}{\linewidth}{@{}l X r@{}}
+    \textbf{#1} & \hfill &  #2 \\[3.75pt]
+    \end{tabularx}
+    }
+    {
+    }
+
+\newenvironment{joblong}[2]
+    {
+    \begin{tabularx}{\linewidth}{@{}l X r@{}}
+    \textbf{#1} & \hfill &  #2 \\[3.75pt]
+    \end{tabularx}
+    \begin{minipage}[t]{\linewidth}
+    \begin{itemize}[nosep,after=\strut, leftmargin=1em, itemsep=3pt,label=--]
+    }
+    {
+    \end{itemize}
+    \end{minipage}    
+    }
+
+
+
 %----------------------------------------------------------------------------------------
 %	BEGIN DOCUMENT
 %----------------------------------------------------------------------------------------
@@ -135,23 +161,16 @@ This CV is automatically generated and deployed using the \href{https://github.c
 %Experience
 \section{Work Experience}
 
-\begin{tabularx}{\linewidth}{ @{}l r@{} }
-\textbf{Designation} & \hfill Jan 2021 - present \\[3.75pt]
-\multicolumn{2}{@{}X@{}}{long long line of blah blah that will wrap when the table fills the column width long long line of blah blah that will wrap when the table fills the column width long long line of blah blah that will wrap when the table fills the column width long long line of blah blah that will wrap when the table fills the column width}  \\
-\end{tabularx}
+\begin{jobshort}{Designation}{Jan 2021 - present}
+long long line of blah blah that will wrap when the table fills the column width long long line of blah blah that will wrap when the table fills the column width long long line of blah blah that will wrap when the table fills the column width long long line of blah blah that will wrap when the table fills the column width
+\end{jobshort}
 
-\begin{tabularx}{\linewidth}{ @{}l r@{} }
-\textbf{Designation} & \hfill Mar 2019 - Jan 2021 \\[3.75pt]
-\multicolumn{2}{@{}X@{}}{
-\begin{minipage}[t]{\linewidth}
-    \begin{itemize}[nosep,after=\strut, leftmargin=1em, itemsep=3pt]
-        \item[--] long long line of blah blah that will wrap when the table fills the column width
-        \item[--] again, long long line of blah blah that will wrap when the table fills the column width but this time even more long long line of blah blah. again, long long line of blah blah that will wrap when the table fills the column width but this time even more long long line of blah blah
-    \end{itemize}
-    \end{minipage}
-}
-\end{tabularx}
 
+\begin{joblong}{Designation}{Mar 2019 - Jan 2021}
+\item long long line of blah blah that will wrap when the table fills the column width
+\item again, long long line of blah blah that will wrap when the table fills the column width but this time even more long long line of blah blah. again, long long line of blah blah that will wrap when the table fills the column width but this time even more long long line of blah blah
+\end{joblong}
+  
 %Projects
 \section{Projects}
 


### PR DESCRIPTION
Dear @jitinnair1 ,

First of all, I'd like to thank you for this wonderfull project, that I'm currently using to do my CV.

You'll find in this pull request proposal two improvements, that **do not change at all** the final rendering of resulting CVs.

* Makefile : the online compilation based on github actions is long (several minutes). As a user, I was willing to be able to compile the CV locally before pushing it to github repository. While I managed to find appropriate commands in file `.github/workflows/build.yml`, it required me about 1 hour. I guess a Makefile in the root directory of the project would allow future users to use this project more easily.
* Work Experience environments : I defined two environment commands `\jobshort` and `\joblong` allowing to reproduce the rendering of your proposal for listing job experiences. These environments allow to add new jobs with less lines of codes and to use `\item` commands instead of `\item[--]`. In my use-case, I need to list about 15 different jobs in 2 different languages - and having such environments allow me to add new jobs with less lines of code (defining a custom tabularx for each job is definitely annoying for large quantities of jobs, and makes it difficult to apply rendering changes to such a list).

Hoping you'll like this proposal, and that it would be useful for other users.

Last thing : I did some modifications in my own CV allowing to add my picture, and meta-data in resulting pdf containing my name and some keywords. If you think it would be a good idea to add this option to the project, I can make another pull request: see an example bellow : 
https://github.com/DavidDoukhan/david_doukhan_detailed_cv
